### PR TITLE
fix: campo formação recebe valor negativo

### DIFF
--- a/src/_adapters/voluntarios/dto/create-voluntario.dto.ts
+++ b/src/_adapters/voluntarios/dto/create-voluntario.dto.ts
@@ -169,6 +169,7 @@ export class CreateVoluntarioDto implements Omit<NovoVoluntario, 'usuario'> {
   @IsPositive({
     message: '$property deve ser maior do que zero',
   })
+  @Min(1900)
   anoFormacao: number;
 
   /***

--- a/src/_adapters/voluntarios/dto/create-voluntario.dto.ts
+++ b/src/_adapters/voluntarios/dto/create-voluntario.dto.ts
@@ -8,6 +8,7 @@ import {
   IsNotEmpty,
   IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
   Max,
   Min,
@@ -164,6 +165,9 @@ export class CreateVoluntarioDto implements Omit<NovoVoluntario, 'usuario'> {
   )
   @IsNotEmpty({
     message: '$property não deve ser vazio',
+  })
+  @IsPositive({
+    message: '$property deve ser maior do que zero',
   })
   anoFormacao: number;
 


### PR DESCRIPTION
**Resultado Atual**

O Campo **Ano Formação** está permitindo cadastro com um ano inválido.

**Correção**

Foi feita uma validação para que não seja mais possível preencher esse campo com um valor não aceitável.